### PR TITLE
Add missing salary entry lookup

### DIFF
--- a/js/modules/enhancedDataService.js
+++ b/js/modules/enhancedDataService.js
@@ -727,13 +727,22 @@ export class DataStore {
         
         return false;
     }
-    
+
     /**
      * Get all salary entries
      * @returns {Array} Salary entries
      */
     getSalaryHistory() {
         return [...this.data.salaryHistory];
+    }
+
+    /**
+     * Get a single salary entry by ID
+     * @param {string} entryId - Entry ID
+     * @returns {Object|null} The salary entry or null if not found
+     */
+    getSalaryEntry(entryId) {
+        return this.data.salaryHistory.find(entry => entry.id === entryId) || null;
     }
     
     /**


### PR DESCRIPTION
## Summary
- fix editing salary entries by adding `getSalaryEntry` to the data service

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68400187e20c8325802839325ba8894f