### PR TITLE
Add Jest tests for DataStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Your financial data never leaves your computer - everything is stored locally in
 
 This project is open source and available under the MIT License.
 
+## Running Tests
+
+After cloning the repository and installing the dependencies, run:
+
+```bash
+npm test
+```
+
+This executes the Jest test suite located in the `tests/` directory.
+
 ## Contributions
 
 Contributions, issues, and feature requests are welcome! 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "networthtacker-vibecoding",
+  "version": "1.0.0",
+  "description": "A simple yet powerful web application to track your net worth over time, built using vanilla HTML, CSS, and JavaScript.",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/dataStore.test.js
+++ b/tests/dataStore.test.js
@@ -1,0 +1,44 @@
+import { DataStore } from '../js/modules/enhancedDataService.js';
+
+class StorageMock {
+  constructor() { this.store = {}; }
+  getItem(key) { return this.store[key] || null; }
+  setItem(key, value) { this.store[key] = value; }
+  removeItem(key) { delete this.store[key]; }
+}
+
+describe('DataStore', () => {
+  let store;
+  let dataStore;
+  beforeEach(() => {
+    global.document = { dispatchEvent: jest.fn() };
+    global.CustomEvent = function(name, params) { return { name, ...params }; };
+    store = new StorageMock();
+    dataStore = new DataStore(store);
+  });
+
+  test('addYear creates a new year and triggers event', () => {
+    const listener = jest.fn();
+    dataStore.addEventListener('yearAdded', listener);
+    const result = dataStore.addYear(2025);
+    expect(result).toBe(true);
+    expect(dataStore.data.years[2025]).toBeDefined();
+    expect(listener).toHaveBeenCalledWith({ year: 2025 });
+  });
+
+  test('addYear does not add duplicate year', () => {
+    dataStore.addYear(2025);
+    const result = dataStore.addYear(2025);
+    expect(result).toBe(false);
+  });
+
+  test('removeYear deletes year and triggers event', () => {
+    dataStore.addYear(2024);
+    const listener = jest.fn();
+    dataStore.addEventListener('yearRemoved', listener);
+    const result = dataStore.removeYear(2024);
+    expect(result).toBe(true);
+    expect(dataStore.data.years[2024]).toBeUndefined();
+    expect(listener).toHaveBeenCalledWith({ year: 2024 });
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest config and package.json
- add unit tests for DataStore addYear/removeYear
- document `npm test` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005007d488325bd33fe06678cf97e