### PR TITLE
Fix setup script and test config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A simple yet powerful web application to track your net worth over time, built u
 ### Installation
 
 1. Clone or download this repository.
-2. *(Optional)* Run `./setup.sh` to install the Node.js dependencies. This step is required if you want to run the test suite.
+2. *(Optional)* Run `./setup.sh` to install the Node.js dependencies. This step requires Node.js v18 or newer and is only necessary if you want to run the test suite.
 3. Open `index.html` in your web browser.
 
 No server setup or installation is required for basic usage&mdash;the application runs entirely in your browser. The setup script simply installs the development dependencies so that `npm test` works.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
 export default {
-  testEnvironment: 'jsdom',
+  testEnvironment: 'node',
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "keywords": [],
   "author": "",

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,14 @@ if ! command -v node >/dev/null 2>&1; then
     exit 1
 fi
 
+# Ensure minimum Node version
+NODE_MAJOR=$(node -v | sed 's/v\([0-9]*\).*/\1/')
+if [ "$NODE_MAJOR" -lt 18 ]; then
+    echo "Error: Detected Node.js v$NODE_MAJOR. Please install Node.js v18 or newer." >&2
+    exit 1
+fi
+
 # Install project dependencies
-npm install
+npm install --no-audit --no-fund
 
 echo "Setup complete. You can run 'npm test' to execute the test suite."

--- a/tests/dataStore.test.js
+++ b/tests/dataStore.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { DataStore } from '../js/modules/enhancedDataService.js';
 
 class StorageMock {


### PR DESCRIPTION
## Summary
- ensure Node.js v18+ when running setup
- use `npm install --no-audit --no-fund` in `setup.sh`
- run Jest in Node ESM mode
- import `jest` globals explicitly in tests
- document Node 18 requirement for running tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840080d350883259279d1ec6180a745